### PR TITLE
Get wrapper instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,9 @@ The returned component accepts a `theme` and `composeTheme`  apart from the prop
 
 - `Identifier` *(String)* used to provide a unique identifier to the component that will be used to get a theme from context.
 - `[defaultTheme]` (*Object*) is  classname object resolved from CSS modules. It will be used as the default theme to calculate a new theme that will be passed to the component.
-- `[options]` (*Object*) is an option object that for now only accepts one value: `composeTheme` which accepts:
-  - `deeply` to deeply merge themes.
-  - `softly` to softly merge themes.
-  - `false` to disable theme merging.
+- `[options]` (*Object*) If specified it allows to customize the behavior: 
+  - [`composeTheme = 'deeply'`] *(String)* allows to customize the way themes are merged or to disable merging completely. The accepted values are `deeply` to deeply merge themes, `softly` to softly merge themes and `false` to disable theme merging.
+  - [`withRef = false`] *(Boolean)* if true, stores a ref to the wrapped component instance and makes it available via `getWrappedInstance()` method. Defaults to false.
 
 ## About
 

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0"
+  },
+  "dependencies": {
+    "invariant": "^2.2.1"
   }
 }

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -273,4 +273,55 @@ describe('Themr decorator function', () => {
     const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough)
     expect(stub.props.theme).toEqual({})
   })
+
+  it('should throw when trying to access the wrapped instance if withRef is not specified', () => {
+    const theme = { Container: { foo: 'foo_1234' } }
+
+    @themr('Container')
+    class Container extends Component {
+      render() {
+        return <Passthrough {...this.props} />
+      }
+    }
+
+    const tree = TestUtils.renderIntoDocument(
+      <ProviderMock theme={theme}>
+        <Container />
+      </ProviderMock>
+    )
+
+    const container = TestUtils.findRenderedComponentWithType(tree, Container)
+    expect(() => container.getWrappedInstance()).toThrow(
+      /To access the wrapped instance, you need to specify \{ withRef: true \} as the third argument of the themr\(\) call\./
+    )
+  })
+
+  it('should return the instance of the wrapped component for use in calling child methods', () => {
+    const someData = {
+      some: 'data'
+    }
+
+    class Container extends Component {
+      someInstanceMethod() {
+        return someData
+      }
+
+      render() {
+        return <Passthrough />
+      }
+    }
+
+    const decorator = themr('Component', null, { withRef: true })
+    const Decorated = decorator(Container)
+
+    const tree = TestUtils.renderIntoDocument(
+      <Decorated />
+    )
+
+    const decorated = TestUtils.findRenderedComponentWithType(tree, Decorated)
+
+    expect(() => decorated.someInstanceMethod()).toThrow()
+    expect(decorated.getWrappedInstance().someInstanceMethod()).toBe(someData)
+    expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData)
+  })
 })


### PR DESCRIPTION
This PR adds a new method for the decorator component that allows to retrieve a reference from the decorated component. This is useful for use cases where the component has imperative methods that can be called from a parent.

The most straightforward case is an `Input` component. Since the `focus` state is implemented in the native `input`, to remove the focus it's a common pattern to retrieve the `DOM` element instance using a `ref` of `findDOMNode` and to call `blur()` over the given element. This way, an `Input` component that is rendering a native `input` would typically have both `blur` and `focus` methods.

Decorating this kind of component doesn't allow to access the ref to call instance methods so we followed the same pattern as [react-redux](https://github.com/reactjs/react-redux/blob/master/src/components/connect.js#L265-L272). Since functional components cannot hold refs, you can pass from now on a new parameter `withRef` to indicate if the wrapper should render with a reference. Then you can use `getWrappedInstance` to get the instance. 

Example:
```js
import React, { Component } from 'react'
import { themr } from 'react-css-themr'
import Input from './Input.js'
import theme from 'theme.css'

const ThemedInput = themr('MyThemedInput', theme, { withRef: true })

class BlurMyInput extends Component {
  handleClick = () => {
    this._input.getWrappedInstance().focus();
  }

  render() {
    return (
      <div>
        <button onClick={this.handleClick}>Click me to focus input</button>
        <ThemedInput ref={c => this._input = c} />
      </div>
    )
  }  
}
```
 