### PR TITLE
Add namespace support

### DIFF
--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -47,7 +47,7 @@ export default (componentName, localTheme, options = {}) => (ThemedComponent) =>
 
       return Object.keys(theme)
         .filter(key => key.startsWith(themeNamespace))
-        .reduce((p, c) => ({ ...p, [removeNamespace(c, themeNamespace)]:  theme[c] }), {})
+        .reduce((result, key) => ({ ...result, [removeNamespace(key, themeNamespace)]:  theme[key] }), {})
     }
 
     getThemeNotComposed() {

--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -23,7 +23,7 @@ export default (componentName, localTheme, options = {}) => (ThemedComponent) =>
     static propTypes = {
       composeTheme: PropTypes.oneOf([ COMPOSE_DEEPLY, COMPOSE_SOFTLY, DONT_COMPOSE ]),
       theme: PropTypes.object,
-      namespace: PropTypes.string
+      themeNamespace: PropTypes.string
     }
 
     static defaultProps = {
@@ -40,14 +40,14 @@ export default (componentName, localTheme, options = {}) => (ThemedComponent) =>
     }
 
     getNamespacedTheme() {
-      const { namespace, theme } = this.props
-      if (!namespace) return theme
-      if (namespace &&  !theme) throw new Error('Invalid namespace use in react-css-themr. ' +
-        'Namespace prop should be used only with theme prop.')
+      const { themeNamespace, theme } = this.props
+      if (!themeNamespace) return theme
+      if (themeNamespace &&  !theme) throw new Error('Invalid themeNamespace use in react-css-themr. ' +
+        'themeNamespace prop should be used only with theme prop.')
 
       return Object.keys(theme)
-        .filter(key => key.startsWith(namespace))
-        .reduce((p, c) => ({ ...p, [removeNamespace(c, namespace)]:  theme[c] }), {})
+        .filter(key => key.startsWith(themeNamespace))
+        .reduce((p, c) => ({ ...p, [removeNamespace(c, themeNamespace)]:  theme[c] }), {})
     }
 
     getThemeNotComposed() {
@@ -114,7 +114,7 @@ function validateComposeOption(composeTheme) {
   }
 }
 
-function removeNamespace(key, namespace) {
-  const capitilized = key.substr(namespace.length)
+function removeNamespace(key, themeNamespace) {
+  const capitilized = key.substr(themeNamespace.length)
   return capitilized.slice(0, 1).toLowerCase() + capitilized.slice(1)
 }

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -324,4 +324,45 @@ describe('Themr decorator function', () => {
     expect(decorated.getWrappedInstance().someInstanceMethod()).toBe(someData)
     expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData)
   })
+
+  it('should throw if namespace passed without theme', () => {
+    const theme = { Container: { foo: 'foo_1234' } }
+
+    @themr('Container')
+    class Container extends Component {
+      render() {
+        return <Passthrough {...this.props} />
+      }
+    }
+
+    expect(() => TestUtils.renderIntoDocument(
+      <ProviderMock theme={theme}>
+        <Container namespace="container"/>
+      </ProviderMock>
+    )).toThrow(/Invalid namespace use in react-css-themr. Namespace prop should be used only with theme prop./)
+  })
+
+  it('when providing a namespace prop composes a theme', () => {
+    const containerTheme = { foo: 'foo_123' }
+    const containerThemeLocal = { foo: 'foo_567' }
+    const containerThemeProps = { foo: 'foo_89', containerFoo: 'foo_000' }
+    const theme = { Container: containerTheme }
+
+    @themr('Container', containerThemeLocal)
+    class Container extends Component {
+      render() {
+        return <Passthrough {...this.props} />
+      }
+    }
+
+    const tree = TestUtils.renderIntoDocument(
+      <ProviderMock theme={theme}>
+        <Container theme={containerThemeProps} namespace="container" />
+      </ProviderMock>
+    )
+
+    const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough)
+    const expectedTheme = { foo: 'foo_123 foo_567 foo_000' }
+    expect(stub.props.theme).toEqual(expectedTheme)
+  })
 })

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -325,7 +325,7 @@ describe('Themr decorator function', () => {
     expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData)
   })
 
-  it('should throw if namespace passed without theme', () => {
+  it('should throw if themeNamespace passed without theme', () => {
     const theme = { Container: { foo: 'foo_1234' } }
 
     @themr('Container')
@@ -337,12 +337,12 @@ describe('Themr decorator function', () => {
 
     expect(() => TestUtils.renderIntoDocument(
       <ProviderMock theme={theme}>
-        <Container namespace="container"/>
+        <Container themeNamespace="container"/>
       </ProviderMock>
-    )).toThrow(/Invalid namespace use in react-css-themr. Namespace prop should be used only with theme prop./)
+    )).toThrow(/Invalid themeNamespace use in react-css-themr. themeNamespace prop should be used only with theme prop./)
   })
 
-  it('when providing a namespace prop composes a theme', () => {
+  it('when providing a themeNamespace prop composes a theme', () => {
     const containerTheme = { foo: 'foo_123' }
     const containerThemeLocal = { foo: 'foo_567' }
     const containerThemeProps = { foo: 'foo_89', containerFoo: 'foo_000' }
@@ -357,7 +357,7 @@ describe('Themr decorator function', () => {
 
     const tree = TestUtils.renderIntoDocument(
       <ProviderMock theme={theme}>
-        <Container theme={containerThemeProps} namespace="container" />
+        <Container theme={containerThemeProps} themeNamespace="container" />
       </ProviderMock>
     )
 


### PR DESCRIPTION
Result of discussing started in https://github.com/javivelasco/react-css-themr/issues/11

```js
import theme from './section.css';

const Section = () => (
  <section className={theme.content}>
    <Button theme={theme} namespace="button" />
  </section>
);
```

```css
/* Section.css */
.content {
  border: 1px solid red;
}

.buttonContent {
  color: red;
}
```

If `namespace` prop set, only namespaced keys will be passed to the component within `theme`. I.e. `content` will be dropped, `buttonContent` will be converted to `content`.