### PR TITLE
Copy statics

### DIFF
--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -21,12 +21,14 @@ export default (componentName, localTheme, options = {}) => (ThemedComponent) =>
     }
 
     static propTypes = {
+      ...ThemedComponent.propTypes,
       composeTheme: PropTypes.oneOf([ COMPOSE_DEEPLY, COMPOSE_SOFTLY, DONT_COMPOSE ]),
       theme: PropTypes.object,
       themeNamespace: PropTypes.string
     }
 
     static defaultProps = {
+      ...ThemedComponent.defaultProps,
       composeTheme: optionComposeTheme
     }
 

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -250,7 +250,7 @@ describe('Themr decorator function', () => {
   it('throws an error if an invalid composition option passed', () => {
     expect(() => {
       @themr('Container', null, { composeTheme: 'foo' })
-      class Container extends Component {
+      class Container extends Component { //eslint-disable-line no-unused-vars
         render() {
           return <Passthrough {...this.props} />
         }
@@ -369,16 +369,16 @@ describe('Themr decorator function', () => {
   it('should copy statics from ThemedComponent', () => {
     const propTypes = {
       foo: PropTypes.array
-    };
+    }
     const defaultProps = {
       foo: []
-    };
+    }
     @themr('Foo')
     class Foo extends Component {
       static propTypes = propTypes;
       static defaultProps = defaultProps;
     }
-    expect(Foo.propTypes.foo).toBe(propTypes.foo);
-    expect(Foo.defaultProps.foo).toBe(defaultProps.foo);
+    expect(Foo.propTypes.foo).toBe(propTypes.foo)
+    expect(Foo.defaultProps.foo).toBe(defaultProps.foo)
   })
 })

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -248,14 +248,14 @@ describe('Themr decorator function', () => {
   })
 
   it('throws an error if an invalid composition option passed', () => {
-    expect(() => (
+    expect(() => {
       @themr('Container', null, { composeTheme: 'foo' })
       class Container extends Component {
         render() {
           return <Passthrough {...this.props} />
         }
       }
-    )).toThrow(/composeTheme/)
+    }).toThrow(/composeTheme/)
   })
 
   it('works properly when no theme is provided', () => {

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -365,4 +365,20 @@ describe('Themr decorator function', () => {
     const expectedTheme = { foo: 'foo_123 foo_567 foo_000' }
     expect(stub.props.theme).toEqual(expectedTheme)
   })
+
+  it('should copy statics from ThemedComponent', () => {
+    const propTypes = {
+      foo: PropTypes.array
+    };
+    const defaultProps = {
+      foo: []
+    };
+    @themr('Foo')
+    class Foo extends Component {
+      static propTypes = propTypes;
+      static defaultProps = defaultProps;
+    }
+    expect(Foo.propTypes.foo).toBe(propTypes.foo);
+    expect(Foo.defaultProps.foo).toBe(defaultProps.foo);
+  })
 })


### PR DESCRIPTION
Changes in this PR provide access to original static fields for further reusage.
```
@themr('Foo')
class Foo extends React.Component {
	static propTypes = {
		foo: React.PropTypes.array
	}
	static defaultProps = {
		foo: []
	}
}

@themr('Bar')
class Bar extends React.Component {
	static propTypes = {
		...Foo.propTypes
	}
	
	static defaultProps = {
		...Foo.defaultProps
	}
}
```

Technical details:
`@themr`'s injected propTypes go after original so they always override propTypes with "reserverd" keys like `theme` etc.