### PR TITLE
flatten multiple wrapping

### DIFF
--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -381,4 +381,18 @@ describe('Themr decorator function', () => {
     expect(Foo.propTypes.foo).toBe(propTypes.foo)
     expect(Foo.defaultProps.foo).toBe(defaultProps.foo)
   })
+
+  it('should not wrap multiple time if used with already wrapped component with the same key', () => {
+    const foo = {
+      foo: 'foo'
+    }
+    const bar = {
+      bar: 'bar'
+    }
+    const key = 'Foo'
+    @themr(key, foo)
+    class Foo {}
+    const Bar = themr(key, bar)(Foo)
+    expect(Bar).toBe(Foo)
+  })
 })

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -390,9 +390,22 @@ describe('Themr decorator function', () => {
       bar: 'bar'
     }
     const key = 'Foo'
+
     @themr(key, foo)
-    class Foo {}
+    class Foo extends Component {
+      render() {
+        return <Passthrough {...this.props} />
+      }
+    }
     const Bar = themr(key, bar)(Foo)
     expect(Bar).toBe(Foo)
+
+    const tree = TestUtils.renderIntoDocument(<Bar/>)
+
+    const stub = TestUtils.findRenderedComponentWithType(tree, Passthrough)
+    expect(stub.props.theme).toEqual({
+      ...foo,
+      ...bar
+    })
   })
 })


### PR DESCRIPTION
Changes in this PR provide a performance improval when decorating already decorated component with the same key.
If a component has already been decorated (there's a check for component's name and for an injected Symbol (or just a constant)) then new theme is merged to original one and previous component class is returned. 
Lifecycle of previous component is not affected in any way but localTheme and componentName are now stored on the class as a static field under Symbol (or a constant if environment does not support Symbols).