### PR TITLE
don't use spaces in Themed component display name generation

### DIFF
--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -30,7 +30,7 @@ export default (componentName, localTheme, options = {}) => (ThemedComponent) =>
   }
 
   class Themed extends Component {
-    static displayName = `Themed ${ThemedComponent.name}`;
+    static displayName = `Themed${ThemedComponent.name}`;
 
     static contextTypes = {
       themr: PropTypes.object


### PR DESCRIPTION
This change removes space from Themed component display name. It's a fix for a case when component gets decorated multiple times on different keys and displayName is taken from `ThemedComponent.name` which cannot contain spaces as it's a function.