### PR TITLE
support nested theme objects

### DIFF
--- a/test/components/ThemeProvider.spec.js
+++ b/test/components/ThemeProvider.spec.js
@@ -30,13 +30,13 @@ describe('ThemeProvider', () => {
 
       expect(() => TestUtils.renderIntoDocument(
         <ThemeProvider theme={theme}>
+          <div />
+          <div />
         </ThemeProvider>
       )).toThrow(/exactly one child/)
 
       expect(() => TestUtils.renderIntoDocument(
         <ThemeProvider theme={theme}>
-          <div />
-          <div />
         </ThemeProvider>
       )).toThrow(/exactly one child/)
     } finally {

--- a/test/components/ThemeProvider.spec.js
+++ b/test/components/ThemeProvider.spec.js
@@ -33,12 +33,12 @@ describe('ThemeProvider', () => {
           <div />
           <div />
         </ThemeProvider>
-      )).toThrow(/exactly one child/)
+      )).toThrow(/expected to receive a single React element child/)
 
       expect(() => TestUtils.renderIntoDocument(
         <ThemeProvider theme={theme}>
         </ThemeProvider>
-      )).toThrow(/exactly one child/)
+      )).toThrow(/expected to receive a single React element child/)
     } finally {
       ThemeProvider.propTypes = propTypes
     }

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import React, { Children, PropTypes, Component } from 'react'
 import TestUtils from 'react-addons-test-utils'
-import { themr } from '../../src/index'
+import { themr, themeable } from '../../src/index'
 
 describe('Themr decorator function', () => {
   class Passthrough extends Component {
@@ -407,5 +407,37 @@ describe('Themr decorator function', () => {
       ...foo,
       ...bar
     })
+  })
+})
+
+describe('themeable function', () => {
+  it('should support merging nested objects', () => {
+    const themeA = {
+      test: 'test',
+      nested: {
+        foo: 'foo',
+        bar: 'bar'
+      }
+    }
+
+    const themeB = {
+      test: 'test2',
+      nested: {
+        foo: 'foo2',
+        test: 'test'
+      }
+    }
+
+    const expected = {
+      test: 'test test2',
+      nested: {
+        foo: 'foo foo2',
+        bar: 'bar',
+        test: 'test'
+      }
+    }
+
+    const result = themeable(themeA, themeB)
+    expect(result).toEqual(expected)
   })
 })


### PR DESCRIPTION
This PR provides nested theme objects support - some words about it.
Suppose you have a complex component that accepts child component `class` as props:
```javascript
const CHILD_THEME_SHAPE = {
  child: React.PropTypes.string
}

const Child = ({ theme }) => (
  <div className={theme.container}>
    Hi, I am a basic child!
  </div>
)

Child.propTypes = {
  theme: React.PropTypes.shape(CHILD_THEME_SHAPE)
}

const COMPLEX_THEME_SHAPE = {
  complex: React.PropTypes.string
}

class Complex extends React.Component {
  static propTypes = {
    Child: React.PropTypes.func,
    theme: React.PropTypes.oneOfType([
      React.PropTypes.shape({
        //naive implementation
        ...COMPLEX_THEME_SHAPE,
        ...CHILD_THEME_SHAPE //possible collision here
      }),

      React.PropTypes.shape({
        //improve "namespaced" implementation
        ...COMPLEX_THEME_SHAPE,
        //we can take Child component's name here
        Child: React.PropTypes.shape(CHILD_THEME_SHAPE)
      })
    ])
  }

  static defaultProps = {
    Child
  }

  render() {
    const { Child, theme } = this.props

    //naive solution is to construct child's theme here on the fly
    const childTheme = {
      child: theme.child //keys may be different
    }
    
    return (
      <div className={theme.complex}>
        {/*if you have multiple child component classes yoy end up on constructing theme objects on the fly for each of them*/}
        <Child theme={childTheme}/>
        {/*but you could just pass a nested theme to child's component*/}
        <Child theme={theme.Child}/>
      </div>
    )
  }
}

//render
const render = () => <Complex Child={SomeCustomChildComponent}/>
```

The point is to allow nested objects in theme definition.
Also when using themr context a theme can be easily constructed from multiple css-modules:
```
import complex from './Complex.css'
import child from './Child.css'

const context = {
  Complex: {
    ...Complex,
    Child: child
  }
}
```

Accepting these changes would be extremely nice because it's very tedios to construct dynamic theme in complex components for all nested Child components.

UPDATE: Also PR contains some jsdoc
