### PR TITLE
Fixed typings (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "babel src --out-dir lib",


### PR DESCRIPTION
Fixing #32 broke typings. `index.d.ts` was not included in `files`.