### PR TITLE
Fix mixinValue and originalValue different types case

### DIFF
--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -178,13 +178,13 @@ export function themeable(original = {}, mixin) {
 
     //merging reducer
     (result, key) => {
-      const originalValue = original[key] || ''
-      const mixinValue = mixin[key] || ''
+      const originalValue = (typeof original === 'object' ? original[key] : original) || ''
+      const mixinValue = (typeof mixin === 'object' ? mixin[key] : mixin) || ''
 
       let newValue
 
       //check if values are nested objects
-      if (typeof originalValue === 'object' && typeof mixinValue === 'object') {
+      if (typeof originalValue === 'object' || typeof mixinValue === 'object') {
         //go recursive
         newValue = themeable(originalValue, mixinValue)
       } else {


### PR DESCRIPTION
I managed to make react-toolbox beta4 to work with this fix, but beta5 still fails to compile by react-toolbox-themr for different reasons.