### PR TITLE
Feature/theme spreads

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,12 +27,9 @@ declare module "react-css-themr" {
     new(props?: P, context?: any): ThemedComponent<P, S>;
   }
 
-  interface IThemrDecorator {
-    <P, S>(component: React.ComponentClass<P> | React.SFC<P>): ThemedComponentClass<P, S>,
-    <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>): ThemedComponentClass<P, S>
-  }
-
-  export function themr(identifier: string | number | symbol,
-                        defaultTheme?: {},
-                        options?: IThemrOptions): IThemrDecorator;
+  export function themr(
+    identifier: string | number | symbol,
+    defaultTheme?: {},
+    options?: IThemrOptions
+  ): <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>) => ThemedComponentClass<P, S>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,37 +1,37 @@
 import * as React from "react";
 
-declare module "react-css-themr"
-{
-	export interface IThemrOptions
-	{
-		/** @default "deeply" */
-		composeTheme?: "deeply" | "softly" | false,
-	}
+declare module "react-css-themr" {
+  type TReactCSSThemrTheme = {
+    [key: string]: string | TReactCSSThemrTheme
+  }
 
-	export interface ThemeProviderProps
-	{
+  export function themeable(...themes: Array<TReactCSSThemrTheme>): TReactCSSThemrTheme;
+
+  export interface IThemrOptions {
+    /** @default "deeply" */
+    composeTheme?: "deeply" | "softly" | false,
+  }
+
+  export interface ThemeProviderProps {
     innerRef?: Function,
-		theme: {}
-	}
+    theme: {}
+  }
 
-	export class ThemeProvider extends React.Component<ThemeProviderProps, any>
-	{
+  export class ThemeProvider extends React.Component<ThemeProviderProps, any> {
 
-	}
+  }
 
-	interface ThemedComponent<P, S> extends React.Component<P, S>
-	{
+  interface ThemedComponent<P, S> extends React.Component<P, S> {
 
-	}
+  }
 
-	interface ThemedComponentClass<P, S> extends React.ComponentClass<P>
-	{
-		new(props?: P, context?: any): ThemedComponent<P, S>;
-	}
+  interface ThemedComponentClass<P, S> extends React.ComponentClass<P> {
+    new(props?: P, context?: any): ThemedComponent<P, S>;
+  }
 
-	export function themr(
-		identifier: string,
-		defaultTheme?: {},
-		options?: IThemrOptions
-	): <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>) => ThemedComponentClass<P, S>;
+  export function themr(
+    identifier: string,
+    defaultTheme?: {},
+    options?: IThemrOptions
+  ): <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>) => ThemedComponentClass<P, S>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,9 +27,9 @@ declare module "react-css-themr" {
     new(props?: P, context?: any): ThemedComponent<P, S>;
   }
 
-  export function themr(
-    identifier: string | number | symbol,
-    defaultTheme?: {},
-    options?: IThemrOptions
-  ): <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>) => ThemedComponentClass<P, S>;
+  type TThemrDecorator = <P, S>(component: React.ComponentClass<P> | React.SFC<P>) => ThemedComponentClass<P, S>;
+
+  export function themr(identifier: string | number | symbol,
+                        defaultTheme?: {},
+                        options?: IThemrOptions): TThemrDecorator;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,9 +27,12 @@ declare module "react-css-themr" {
     new(props?: P, context?: any): ThemedComponent<P, S>;
   }
 
-  type TThemrDecorator = <P, S>(component: React.ComponentClass<P> | React.SFC<P>) => ThemedComponentClass<P, S>;
+  interface IThemrDecorator {
+    <P, S>(component: React.ComponentClass<P> | React.SFC<P>): ThemedComponentClass<P, S>,
+    <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>): ThemedComponentClass<P, S>
+  }
 
   export function themr(identifier: string | number | symbol,
                         defaultTheme?: {},
-                        options?: IThemrOptions): TThemrDecorator;
+                        options?: IThemrOptions): IThemrDecorator;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,5 +31,5 @@ declare module "react-css-themr" {
     identifier: string | number | symbol,
     defaultTheme?: {},
     options?: IThemrOptions
-  ): <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>) => ThemedComponentClass<P, S>;
+  ): <P, S>(component: (new(props?: P, context?: any) => React.Component<P, S>) | React.SFC<P>) => ThemedComponentClass<P, S>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,11 +18,9 @@ declare module "react-css-themr" {
   }
 
   export class ThemeProvider extends React.Component<ThemeProviderProps, any> {
-
   }
 
   interface ThemedComponent<P, S> extends React.Component<P, S> {
-
   }
 
   interface ThemedComponentClass<P, S> extends React.ComponentClass<P> {
@@ -30,7 +28,7 @@ declare module "react-css-themr" {
   }
 
   export function themr(
-    identifier: string,
+    identifier: string | number | symbol,
     defaultTheme?: {},
     options?: IThemrOptions
   ): <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>) => ThemedComponentClass<P, S>;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "invariant": "^2.2.1"
   },
   "devDependencies": {
+    "@types/react": "~15.0.4",
     "babel-cli": "^6.7.7",
     "babel-core": "^6.18.0",
     "babel-eslint": "^7.1.1",

--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -207,6 +207,7 @@ function merge(original = {}, mixin = {}) {
         break
       }
 
+      case 'undefined': //fallthrough - handles accidentally unset values which may come from props
       case 'function': {
         //this handles issue when isomorphic-style-loader addes helper functions to css-module
         break //just skip

--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -152,7 +152,21 @@ export default (componentName, localTheme, options = {}) => (ThemedComponent) =>
   return Themed
 }
 
-export function themeable(original = {}, mixin = {}) {
+/**
+ * Merges passed themes by concatenating string keys and processing nested themes
+ * @param {...TReactCSSThemrTheme} themes - Themes
+ * @returns {TReactCSSThemrTheme} - Resulting theme
+ */
+export function themeable(...themes) {
+  return themes.reduce((acc, theme) => merge(acc, theme), {})
+}
+
+/**
+ * @param {TReactCSSThemrTheme} [original] - Original theme
+ * @param {TReactCSSThemrTheme} [mixin] - Mixin theme
+ * @returns {TReactCSSThemrTheme} - resulting theme
+ */
+function merge(original = {}, mixin = {}) {
   //make a copy to avoid mutations of nested objects
   //also strip all functions injected by isomorphic-style-loader
   const result = Object.keys(original).reduce((acc, key) => {
@@ -175,7 +189,7 @@ export function themeable(original = {}, mixin = {}) {
         switch (typeof originalValue) {
           case 'object': {
             //exactly nested theme object - go recursive
-            result[key] = themeable(originalValue, mixinValue)
+            result[key] = merge(originalValue, mixinValue)
             break
           }
 

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -588,4 +588,23 @@ describe('themeable function', () => {
     }
     expect(() => themeable(themeA, themeB)).toThrow()
   })
+
+  it('should support theme spreads', () => {
+    const a = {
+      test: 'a'
+    }
+    const b = {
+      test: 'b'
+    }
+    const c = {
+      test: 'foo',
+      foo: 'foo'
+    }
+    const expected = {
+      test: 'a b foo',
+      foo: 'foo'
+    }
+    const result = themeable(a, b, c)
+    expect(result).toEqual(expected)
+  })
 })

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -607,4 +607,16 @@ describe('themeable function', () => {
     const result = themeable(a, b, c)
     expect(result).toEqual(expected)
   })
+
+  it('should skip undefined mixin values', () => {
+    const a = {
+      test: 'a'
+    }
+    const b = {
+      test: undefined
+    }
+    const expected = a
+    const result = themeable(a, b)
+    expect(result).toEqual(expected)
+  })
 })

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -510,7 +510,7 @@ describe('themeable function', () => {
     expect(result).toEqual(expected)
   })
 
-  it('should skip dupplicated keys classNames', () => {
+  it('should skip duplicated keys classNames', () => {
     const themeA = { test: 'test' }
     const themeB = { test: 'test test2' }
     const expected = { test: 'test test2' }
@@ -518,9 +518,74 @@ describe('themeable function', () => {
     expect(result).toEqual(expected)
   })
 
-  it('throws an exception when its called mixing a string with an object', () => {
-    expect(() => {
-      themeable('fail', { test: { foo: 'baz' } })
-    }).toThrow(/sure you are passing the proper theme descriptors/)
+  it('should take mixin value if original does not contain one', () => {
+    const themeA = {}
+    const themeB = {
+      test: 'test',
+      nested: {
+        bar: 'bar'
+      }
+    }
+    const expected = themeB
+    const result = themeable(themeA, themeB)
+    expect(result).toEqual(expected)
+  })
+
+  it('should take original value if mixin does not contain one', () => {
+    const themeA = {
+      test: 'test',
+      nested: {
+        bar: 'bar'
+      }
+    }
+    const themeB = {}
+    const expected = themeA
+    const result = themeable(themeA, themeB)
+    expect(result).toEqual(expected)
+  })
+
+  it('should skip function values for usage with isomorphic-style-loader', () => {
+    const themeA = {
+      test: 'test',
+      foo() {
+      }
+    }
+
+    const themeB = {
+      test: 'test2',
+      bar() {
+      }
+    }
+
+    const expected = {
+      test: [
+        themeA.test, themeB.test
+      ].join(' ')
+    }
+
+    const result = themeable(themeA, themeB)
+    expect(result).toEqual(expected)
+  })
+
+  it('should throw when merging objects with non-objects', () => {
+    const themeA = {
+      test: 'test'
+    }
+    const themeB = {
+      test: {
+      }
+    }
+    expect(() => themeable(themeA, themeB)).toThrow()
+  })
+
+  it('should throw when merging non-objects with objects', () => {
+    const themeA = {
+      test: {
+      }
+    }
+    const themeB = {
+      test: 'test'
+    }
+    expect(() => themeable(themeA, themeB)).toThrow()
   })
 })


### PR DESCRIPTION
Hi @javivelasco!
Firstly, my congrats on getting to 2.0 major!

Now about this PR.
Currently it's only possible to construct complex themes from more than two modules by composing `themeable` function which is far from convenient. Taking ES6 spreads into account this PR provides possibility to pass more than two arguments to `themeable`:

```javascript
const a = {
  test: 'a'
}
const b = {
  test: 'b'
}
const c = {
  test: 'foo',
  foo: 'foo'
}
const expected = {
  test: 'a b foo',
  foo: 'foo'
}
const result = themeable(a, b, c)
expect(result).toEqual(expected)
```

Also it contains some refactoring of `themeable` function as it started to grow with type-check conditionals and setting of default values which is all pretty hard to maintain.

All tests pass, so take a look!

**Update**: I have found some TS typings added quite recently. Also `themr` build step is simple as hell - just a `babel` run. So I'd like to suggest switching to TS completely to be fully consistent with these typings and to enforce some real type checking. This is just a suggestion and I could prepare a simple PR with all code rewritten to TS. What do you think?