### PR TITLE
fix/accept sfc as component in themr typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ declare module "react-css-themr"
 	}
 
 	export function themr(
-		identifier: string,
+		identifier: string | number | symbol,
 		defaultTheme?: {},
 		options?: IThemrOptions
   ): <P, S>(component: (new(props?: P, context?: any) => React.Component<P, S>) | React.SFC<P>) => ThemedComponentClass<P, S>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,5 +33,5 @@ declare module "react-css-themr"
 		identifier: string,
 		defaultTheme?: {},
 		options?: IThemrOptions
-	): <P, S>(component: (new(props?: P, context?: any) => React.Component<P, S> | React.SFC<P>)) => ThemedComponentClass<P, S>;
+  ): <P, S>(component: (new(props?: P, context?: any) => React.Component<P, S>) | React.SFC<P>) => ThemedComponentClass<P, S>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,5 +33,5 @@ declare module "react-css-themr"
 		identifier: string,
 		defaultTheme?: {},
 		options?: IThemrOptions
-	): <P, S>(component: new(props?: P, context?: any) => React.Component<P, S>) => ThemedComponentClass<P, S>;
+	): <P, S>(component: (new(props?: P, context?: any) => React.Component<P, S> | React.SFC<P>)) => ThemedComponentClass<P, S>;
 }


### PR DESCRIPTION
This fix allows `themr` decorator to accept `React.SFC` and is related to #39 
Here are test cases:
```typescript
type TFooProps = {
	foo: string
};

type TFooState = {
	bar: number
};

@themr('Symbol()') //ok
class FooClass extends React.Component<TFooProps, TFooState> {
	state = { //ok
		bar: 2123
	};

	render() {
		return <div>hi</div>;
	}
}

const Foo2 = themr('Symbol()')(FooClass); //ok

const FN: React.SFC<TFooProps> = props => (
	<div>hi</div>
);

const fn = themr(Symbol())(FN); //ok
```