### PR TITLE
Proof of Concept: `withNamedThemes` Decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fbjs": "^0.8.4",
     "jsdom": "^9.8.3",
     "mocha": "^3.2.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.3.2",

--- a/src/components/ThemeProvider.js
+++ b/src/components/ThemeProvider.js
@@ -1,4 +1,5 @@
-import { Children, Component, PropTypes } from 'react'
+import { Children, Component } from 'react'
+import PropTypes from 'prop-types'
 import themrShape from '../utils/themr-shape'
 
 export default class ThemeProvider extends Component {

--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import invariant from 'invariant'
 
 /**

--- a/src/components/withNamedThemes.js
+++ b/src/components/withNamedThemes.js
@@ -2,34 +2,70 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import themr from './themr'
 
-const withNamedThemes = (elementName, themesByName) => Element => {
+const getNamedTheme = (themesByName, nameOrTheme) => {
+  let namedTheme
+
+  if (
+    typeof nameOrTheme === 'string' &&
+    typeof themesByName === 'object' &&
+    themesByName !== null &&
+    typeof themesByName[nameOrTheme] === 'object' &&
+    themesByName[nameOrTheme] !== null
+  ) {
+    namedTheme = themesByName[nameOrTheme]
+  } else if (typeof nameOrTheme === 'object' && nameOrTheme !== null) {
+    namedTheme = nameOrTheme
+  }
+
+  return namedTheme
+}
+
+const isThemeProp = themeProp =>
+  typeof themeProp === 'string' ||
+  (typeof themeProp === 'object' && themeProp !== null)
+
+const withNamedThemes = (elementName, themesByName, defaultThemeName) => Element => {
   const ThemeableElementDisplayName = `Themed${elementName || Element.displayName || 'Element'}WithNamedThemes`
 
   const NamedThemeElementWrapper = ({ theme, ...rest }) => {
-    let namedTheme
-    const themeProp = theme || Element.defaultProps.theme
+    let firstThemeProp
+    let secondThemeProp
 
-    if (
-      typeof themeProp === 'string' &&
-      typeof themesByName === 'object' &&
-      themesByName !== null &&
-      typeof themesByName[themeProp] === 'object' &&
-      themesByName[themeProp] !== null
-    ) {
-      namedTheme = themesByName[themeProp]
-    } else if (typeof themeProp === 'object' && themeProp !== null) {
-      namedTheme = themeProp
+    if (Array.isArray(theme) === true && theme.length >= 1) {
+      if (isThemeProp(theme[0]) === true) {
+        firstThemeProp = theme[0]
+      }
+
+      if (isThemeProp(theme[1]) === true) {
+        secondThemeProp = theme[1]
+      }
+    } else {
+      const possibleFirstThemeProp = theme || defaultThemeName || Element.defaultProps.theme
+      if (isThemeProp(possibleFirstThemeProp) === true) {
+        firstThemeProp = possibleFirstThemeProp
+      }
     }
 
-    const ThemedElement = themr(ThemeableElementDisplayName, namedTheme)(Element)
+    const firstTheme = getNamedTheme(themesByName, firstThemeProp)
+    const secondTheme = getNamedTheme(themesByName, secondThemeProp)
 
-    return <ThemedElement {...rest} />
+    const ThemedElement = themr(ThemeableElementDisplayName, firstTheme)(Element)
+    const themedElementProps = {
+      ...rest,
+      theme: secondTheme
+    }
+
+    return <ThemedElement {...themedElementProps} />
   }
 
   NamedThemeElementWrapper.propTypes = {
     theme: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object // eslint-disable-line react/forbid-prop-types
+      PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.object, // eslint-disable-line react/forbid-prop-types
+        PropTypes.string
+      ])),
+      PropTypes.object, // eslint-disable-line react/forbid-prop-types
+      PropTypes.string
     ])
   }
 

--- a/src/components/withNamedThemes.js
+++ b/src/components/withNamedThemes.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import themr from './themr'
+
+const withNamedThemes = (elementName, themesByName) => Element => {
+  const ThemeableElementDisplayName = `Themed${elementName || Element.displayName || 'Element'}WithNamedThemes`
+
+  const NamedThemeElementWrapper = ({ theme, ...rest }) => {
+    let namedTheme
+    const themeProp = theme || Element.defaultProps.theme
+
+    if (
+      typeof themeProp === 'string' &&
+      typeof themesByName === 'object' &&
+      themesByName !== null &&
+      typeof themesByName[themeProp] === 'object' &&
+      themesByName[themeProp] !== null
+    ) {
+      namedTheme = themesByName[themeProp]
+    } else if (typeof themeProp === 'object' && themeProp !== null) {
+      namedTheme = themeProp
+    }
+
+    const ThemedElement = themr(ThemeableElementDisplayName, namedTheme)(Element)
+
+    return <ThemedElement {...rest} />
+  }
+
+  NamedThemeElementWrapper.propTypes = {
+    theme: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object // eslint-disable-line react/forbid-prop-types
+    ])
+  }
+
+  NamedThemeElementWrapper.defaultProps = {
+    theme: undefined
+  }
+
+  return NamedThemeElementWrapper
+}
+
+export default withNamedThemes

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { default as ThemeProvider } from './components/ThemeProvider'
 export { default as themr } from './components/themr'
+export { default as withNamedThemes } from './components/withNamedThemes'
 export { themeable } from './components/themr'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,7 +1364,19 @@ fast-levenshtein@~2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz#bd33145744519ab1c36c3ee9f31f08e9079b67f2"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.4:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.6.tgz#7eb67d6986b2d5007a9b6e92e0e7cb6f75cad290"
   dependencies:
@@ -2339,6 +2351,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2566,6 +2584,10 @@ set-blocking@~2.0.0:
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 shelljs@^0.7.5:
   version "0.7.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/react@~15.0.4":
+  version "15.0.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.23.tgz#f3facbef5290610f54242f00308759d3a3c27346"
+
 abab@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -1195,13 +1199,9 @@ es6-weak-map@^2.0.1:
     es6-iterator "2"
     es6-symbol "3"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-escape-string-regexp@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
 escodegen@^1.6.1:
   version "1.8.1"


### PR DESCRIPTION
Hi @javivelasco,

Thanks for building this: react-css-themr has been instantly useful for the internal library of React components I'm maintaining.

## Introduction
I have a proof-of-concept, in the form of a Pull Request, which I'd like to discuss: a concept of "named themes". The goal is to enable these two use cases:

1. Developers may author a component which internally imports multiple themes, referred to by name
2. Users of said component may pass it a `theme` prop equal to the name of one such theme, as an alternative to passing to a full theme object

Crucially, this assumes the developer is aware of the overhead associated with importing and bundling multiple themes for a single component. In practical use, developers should only implement this design pattern when the cost of statically bundling multiple themes per component is acceptable by their development guidelines.

## Benefits
- Components with multiple themes may expose said themes by name to implementers
- Implementers no longer have to know the name of a theme source file (e.g. for importing), they may simply refer to the component's propTypes (when used in combination with `theme: PropTypes.oneOf(themeNames)`)
- Components decorated with an enhanced HOC to support this approach still have the option to pass a full object-type `theme` down to the composed component

## Proof of Concept
This PR contains a new decorator, `@withNamedThemes`. Below, I provide a usage example, based on an internal, in-development approach I'm taking with an actual component:

### Example: `MyComponent.jsx`
```jsx
import React from 'react';
import PropTypes from 'prop-types';
import { withNamedThemes } from 'react-css-themr';
import normal from './themes/normal.scss';
import alternate from './themes/alternate.scss';

const namedThemes = { normal, alternate };

const MyComponent = ({ theme, children }) => (
  <div className={theme.root}>{children}</div>
);

// Third arg is the name of the default theme, or a theme object
const connectNamedThemes = withNamedThemes('MyComponent', namedThemes, 'normal');

export default connectNamedThemes(MyComponent);
```

### Example Usages
```jsx
import React from 'react';
import MyComponent from './MyComponent';
import fullTheme from './fullTheme.scss';
import partialTheme from './partialTheme.scss';

export default () => (
  <div>
    <MyComponent theme="normal" />
    <MyComponent theme="alternate" />
    <MyComponent theme={fullTheme} />
    {/* Deeply compose `partialTheme` with the 'alternate' theme as the base */}
    <MyComponent theme={['alternate', partialTheme]} />
  </div>
);
```

## Next Steps
- [ ] Determine if this feature is worth including in react-css-themr itself
- [ ] Review the `withNamedThemes` decorator interface / arg order
- [ ] Determine if the existing `@themr` decorator should incorporate this functionality
- [ ] Write tests to cover this new functionality