### PR TITLE
Add mapThemrProps option

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,13 @@ Makes available a `theme` context to use in styled components. The shape of the 
 
 Returns a `function` to wrap a component and make it themeable.
 
-The returned component accepts a `theme`, `composeTheme` and `innerRef` props apart from the props of the original component. They former two are used to provide a `theme` to the component and to configure the style composition, which can be configured via options too, while the latter is used to pass a ref callback to the decorated component. The function arguments are:
+The returned component accepts a `theme`, `composeTheme`, `innerRef` and `mapThemrProps` props apart from the props of the original component. They former two are used to provide a `theme` to the component and to configure the style composition, which can be configured via options too. `innerRef` is used to pass a ref callback to the decorated component and `mapThemrProps` is a function that can be used to map properties to the decorated component. The function arguments are:
 
 - `Identifier` *(String)* used to provide a unique identifier to the component that will be used to get a theme from context.
 - `[defaultTheme]` (*Object*) is  classname object resolved from CSS modules. It will be used as the default theme to calculate a new theme that will be passed to the component.
 - `[options]` (*Object*) If specified it allows to customize the behavior: 
   - [`composeTheme = 'deeply'`] *(String)* allows to customize the way themes are merged or to disable merging completely. The accepted values are `deeply` to deeply merge themes, `softly` to softly merge themes and `false` to disable theme merging.
+  - [`mapThemrProps = (props, theme) => ({ ref, theme })`] *(Function)* allows to customize how properties are passed down to the decorated component. By default, themr extracts all own properties passing down just `innerRef` as `ref` and the generated theme as `theme`. If you are decorating a component that needs to map the reference or any other custom property, this function is called with *all* properties given to the component plus the generated `theme` in the second parameter. It should return the properties you want to pass.
 
 ## About
 

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -293,6 +293,50 @@ describe('Themr decorator function', () => {
     expect(spy.withArgs(stub).calledOnce).toBe(true)
   })
 
+  it('allows to customize props passing using mapThemrProps from props', () => {
+    class Container extends Component {
+      render() {
+        return <Passthrough {...this.props} />
+      }
+    }
+
+    const spy = sinon.stub()
+    const hoc = C => ({ withRef, ...rest }) => (<C ref={withRef} {...rest} />)
+    const customMapper = (props, theme) => {
+      const { composeTheme, innerRef, mapThemrProps, themeNamespace, ...rest } = props //eslint-disable-line no-unused-vars
+      return { withRef: innerRef, theme, className: 'fooClass', ...rest }
+    }
+    const theme = {}
+    const DecoratedContainer = hoc(Container)
+    const ThemedDecoratedContainer = themr('Container', theme)(DecoratedContainer)
+    const tree = TestUtils.renderIntoDocument(<ThemedDecoratedContainer innerRef={spy} mapThemrProps={customMapper} />)
+    const stub = TestUtils.findRenderedComponentWithType(tree, Container)
+    expect(spy.withArgs(stub).calledOnce).toBe(true)
+    expect(stub.props).toMatch({ theme, className: 'fooClass' })
+  })
+
+  it('allows to customize props passing using mapThemrProps from options', () => {
+    class Container extends Component {
+      render() {
+        return <Passthrough {...this.props} />
+      }
+    }
+
+    const spy = sinon.stub()
+    const hoc = C => ({ withRef, ...rest }) => (<C ref={withRef} {...rest} />)
+    const customMapper = (props, theme) => {
+      const { composeTheme, innerRef, mapThemrProps, themeNamespace, ...rest } = props //eslint-disable-line no-unused-vars
+      return { withRef: innerRef, theme, className: 'fooClass', ...rest }
+    }
+    const theme = {}
+    const DecoratedContainer = hoc(Container)
+    const ThemedDecoratedContainer = themr('Container', {}, { mapThemrProps: customMapper })(DecoratedContainer)
+    const tree = TestUtils.renderIntoDocument(<ThemedDecoratedContainer innerRef={spy} />)
+    const stub = TestUtils.findRenderedComponentWithType(tree, Container)
+    expect(spy.withArgs(stub).calledOnce).toBe(true)
+    expect(stub.props).toMatch({ theme, className: 'fooClass' })
+  })
+
   it('should throw if themeNamespace passed without theme', () => {
     const theme = { Container: { foo: 'foo_1234' } }
 


### PR DESCRIPTION
This PR brings a new option and property to the decorator than can be very useful in some scenarios. Until now, we were passing a `ref` prop always to the decorated component with the `withRef` property. This is not always the case: picture that you have a component that is decorated already with an HOC that maps `innerRef` to `ref`. For those cases you can use the new `mapThemrProps` option/prop.

It receives *all* properties given to the component (included themr ones) and the generated theme object and it should return the properties that you want to pass down. For the exposed scenario you might want:

```js
function mapThemrProps(props, theme) {
  const { composeTheme, innerRef, mapThemrProps, themeNamespace, ...rest } = props;
  return { ...rest, withRef: innerRef, theme };
}
```

Check the [tests](https://github.com/javivelasco/react-css-themr/commit/8b7dab8fe15d6cbeff19745ec5e38bfcfde5713e#diff-a8d0360e1ce2281d4f9b22ca5a8e2380R305) to see a full use case.