### PR TITLE
Update themr.js

### DIFF
--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -222,6 +222,13 @@ function merge(original = {}, mixin = {}) {
         switch (typeof originalValue) {
           case 'object': {
             //can't merge a non-object with an object
+            if (mixinValue === '// removed by extract-text-webpack-plugin') {
+              // when the source style is empty / contain only :global rules,
+              // extract-text-webpack-plugin put string instead of json, which break the merge.
+              // this if prevent this specific case
+              // https://github.com/javivelasco/react-css-themr/issues/66
+              break;
+            }
             throw new Error(`You are merging non-object ${mixinValue} with an object ${key}`)
           }
 


### PR DESCRIPTION
when the source style is empty / contain only :global rules, `extract-text-webpack-plugin` put string instead of json, which break the merge.
this if prevent this specific case
https://github.com/javivelasco/react-css-themr/issues/66