### PR TITLE
Update themr.js

### DIFF
--- a/src/components/themr.js
+++ b/src/components/themr.js
@@ -54,7 +54,7 @@ export default (componentName, localTheme, options = {}) => (ThemedComponent) =>
    * @property {{wrappedInstance: *}} refs
    */
   class Themed extends Component {
-    static displayName = `Themed${ThemedComponent.name}`;
+    static displayName = `Themed${(ThemedComponent.displayName || ThemedComponent.name || "Component")}`;
 
     static contextTypes = {
       themr: PropTypes.object


### PR DESCRIPTION
Allows for theming of HOC and components without a function name. Since HOC have different function name than original, we should check for `displayName` 1st and fall back to `Component` for nameless components.