### PR TITLE
Update react api usage to react 16 strict mode compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "fbjs": "^0.8.12",
     "jsdom": "^9.8.3",
     "mocha": "^3.3.0",
-    "prop-types": "^15.5.9",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "prop-types": "^15.7.2",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
     "rimraf": "^2.6.1",
     "sinon": "^1.17.6"
   },
@@ -64,7 +64,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0"
+    "react": "^16.3.0-0"
   },
   "typings": "./index.d.ts"
 }

--- a/src/components/ThemeProvider.js
+++ b/src/components/ThemeProvider.js
@@ -1,30 +1,10 @@
-import { Children, Component } from 'react'
-import PropTypes from 'prop-types'
-import themrShape from '../utils/themr-shape'
+import React, { Children } from 'react'
+import { ThemeContext } from './themr'
 
-export default class ThemeProvider extends Component {
-  static propTypes = {
-    children: PropTypes.element.isRequired,
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    theme: {}
-  }
-
-  static childContextTypes = {
-    themr: themrShape.isRequired
-  }
-
-  getChildContext() {
-    return {
-      themr: {
-        theme: this.props.theme
-      }
-    }
-  }
-
-  render() {
-    return Children.only(this.props.children)
-  }
+export default function ThemeProvider(props) {
+  return (
+    <ThemeContext.Provider value={{ theme: props.theme }}>
+      {Children.only(props.children)}
+    </ThemeContext.Provider>
+  )
 }

--- a/test/components/ThemeProvider.spec.js
+++ b/test/components/ThemeProvider.spec.js
@@ -1,18 +1,19 @@
 import React, { Component } from 'react'
+import { render } from 'react-dom'
 import expect from 'expect'
-import PropTypes from 'prop-types'
 import TestUtils from 'react-dom/test-utils'
 import { ThemeProvider } from '../../src/index'
+import { ThemeContext } from '../../src/components/themr'
 
 describe('ThemeProvider', () => {
   class Child extends Component {
     render() {
-      return <div />
+      return (
+        <ThemeContext.Consumer>
+          {data => JSON.stringify(data)}
+        </ThemeContext.Consumer>
+      )
     }
-  }
-
-  Child.contextTypes = {
-    themr: PropTypes.object.isRequired
   }
 
   it('enforces a single child', () => {
@@ -46,7 +47,7 @@ describe('ThemeProvider', () => {
   })
 
   it('should add the theme to the child context', () => {
-    const theme = {}
+    const theme = { foo: 'bar' }
 
     TestUtils.renderIntoDocument(
       <ThemeProvider theme={theme}>
@@ -55,15 +56,16 @@ describe('ThemeProvider', () => {
     )
 
     const spy = expect.spyOn(console, 'error')
-    const tree = TestUtils.renderIntoDocument(
+    const node = document.createElement('div')
+    render(
       <ThemeProvider theme={theme}>
         <Child />
-      </ThemeProvider>
+      </ThemeProvider>,
+      node
     )
     spy.destroy()
     expect(spy.calls.length).toBe(0)
 
-    const child = TestUtils.findRenderedComponentWithType(tree, Child)
-    expect(child.context.themr.theme).toBe(theme)
+    expect(JSON.parse(node.innerHTML)).toEqual({ theme })
   })
 })

--- a/test/components/themr.spec.js
+++ b/test/components/themr.spec.js
@@ -1,11 +1,12 @@
 import expect from 'expect'
-import React, { Children, Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import TestUtils from 'react-dom/test-utils'
 import sinon from 'sinon'
 import { render } from 'react-dom'
 import shallowEqual from 'fbjs/lib/shallowEqual'
 import { themr, themeable } from '../../src/index'
+import { ThemeProvider } from '../../src/index'
 
 describe('Themr decorator function', () => {
   class Passthrough extends Component {
@@ -15,39 +16,12 @@ describe('Themr decorator function', () => {
     }
   }
 
+
   class ProviderMock extends Component {
-    static childContextTypes = {
-      themr: PropTypes.object.isRequired
-    }
-
-    getChildContext() {
-      return { themr: { theme: this.props.theme } }
-    }
-
     render() {
-      return Children.only(this.props.children)
+      return <ThemeProvider {...this.props} />
     }
   }
-
-  it('passes a context theme object using the component\'s context', () => {
-    const theme = { Container: { foo: 'foo_1234' } }
-
-    @themr('Container')
-    class Container extends Component {
-      render() {
-        return <Passthrough {...this.props} />
-      }
-    }
-
-    const tree = TestUtils.renderIntoDocument(
-      <ProviderMock theme={theme}>
-        <Container />
-      </ProviderMock>
-    )
-
-    const container = TestUtils.findRenderedComponentWithType(tree, Container)
-    expect(container.context.themr.theme).toBe(theme)
-  })
 
   it('passes a context theme object using the component\'s theme prop', () => {
     const containerTheme = { foo: 'foo_1234' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,7 +1384,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz#bd33145744519ab1c36c3ee9f31f08e9079b67f2"
 
-fbjs@^0.8.12, fbjs@^0.8.9:
+fbjs@^0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -1904,6 +1904,11 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@^3.5.1:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -2066,11 +2071,18 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^2.0.0"
 
-loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 micromatch@^2.1.5:
   version "2.3.11"
@@ -2212,6 +2224,11 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
 object-inspect@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.2.1.tgz#3b62226eb8f6d441751c7d8f22a20ff80ac9dc3f"
@@ -2344,12 +2361,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@^15.5.9, prop-types@~15.5.7:
-  version "15.5.9"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
+prop-types@^15.6.2, prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -2375,23 +2394,30 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-dom@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
+react-dom@^16.3.0:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
-    fbjs "^0.8.9"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "~15.5.7"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
-react@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react@^16.3.0:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
-    fbjs "^0.8.9"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.7"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
   version "2.2.9"
@@ -2571,6 +2597,14 @@ samsam@1.1.2, samsam@~1.1:
 sax@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
This should be a new major version number since it requires a new version of react - I believe it just needs to be >=16.3 at this point, because it requires `React.createContext()`.

(I don't have any experience trying to maintain compatibility with both types of context at the same time, unfortunately)

See the reasoning behind these changes [here](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

Also please note that there are two lint errors on this PR, but I don't know anything about JSDoc to know how to fix them.